### PR TITLE
Fix compatibility with fluentd 0.14.1 up to 1.0

### DIFF
--- a/lib/fluent/plugin/in_dynamodb_streams.rb
+++ b/lib/fluent/plugin/in_dynamodb_streams.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class DynamoDBStreamsInput < Input
     Fluent::Plugin.register_input('dynamodb_streams', self)


### PR DESCRIPTION
This fixes compatibility with recent fluentd releases. As far as I've understood it has been broken for years by now.

Hopefully this can be merged and 0.0.4 released. Thanks!