### PR TITLE
Adjust to v1 compatibile layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_script:
 script:
   - bundle exec rake test
   - bundle exec rake build
+after_script:
+  - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/lib/fluent/plugin/in_dynamodb_streams.rb
+++ b/lib/fluent/plugin/in_dynamodb_streams.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 module Fluent
   class DynamoDBStreamsInput < Input
     Fluent::Plugin.register_input('dynamodb_streams', self)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,3 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 require 'fluent/test'
 require 'fluent/plugin/in_dynamodb_streams'
 require 'aws-sdk'


### PR DESCRIPTION
* Require `fluent/input` for Fluentd compatibile layer
* Codecliminate encourages to use codeclimate-test-reporter command instead of requring `codeclimate-test-reporter` and `CodeClimate::TestReporter.start`