### PR TITLE
Aws sdk v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_script:
 script:
   - bundle exec rake test
   - bundle exec rake build
+after_script:
+  - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/fluent-plugin-dynamodb-streams.gemspec
+++ b/fluent-plugin-dynamodb-streams.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", [">= 0.10.58", "< 2"]
-  spec.add_dependency "aws-sdk", '~> 2'
+  spec.add_dependency "aws-sdk-dynamodb", '~> 1'
+  spec.add_dependency "aws-sdk-dynamodbstreams", '~> 1'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/fluent/plugin/in_dynamodb_streams.rb
+++ b/lib/fluent/plugin/in_dynamodb_streams.rb
@@ -10,7 +10,7 @@ module Fluent
 
     def initialize
       super
-      require 'aws-sdk'
+      require 'aws-sdk-dynamodbstreams'
       require 'bigdecimal'
     end
 

--- a/lib/fluent/plugin/in_dynamodb_streams.rb
+++ b/lib/fluent/plugin/in_dynamodb_streams.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 module Fluent
   class DynamoDBStreamsInput < Input
     Fluent::Plugin.register_input('dynamodb_streams', self)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,3 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 require 'fluent/test'
 require 'fluent/plugin/in_dynamodb_streams'
 require 'aws-sdk'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require 'fluent/test'
 require 'fluent/plugin/in_dynamodb_streams'
-require 'aws-sdk'
+require 'aws-sdk-dynamodb'
+require 'aws-sdk-dynamodbstreams'
 
 module DynamoDBStreamsTestHelper
 


### PR DESCRIPTION
Please review after merging #7.

---

AWS SDK v3 had been shipped.
We can use splitted gem instead of monolithic aws-sdk v2 gem.